### PR TITLE
fix: handle only recovery data for the bar

### DIFF
--- a/app/compare/ResultBox/BarUtils.tsx
+++ b/app/compare/ResultBox/BarUtils.tsx
@@ -72,6 +72,7 @@ export function getActiveDuration (activeStr: string) {
 
 export function getRecoveryValue (recovery: number | undefined, activeLast: number) {
   const recoveryTemp = (recovery && recovery) ?? 0;
-  const recoveryCalc = recoveryTemp - activeLast > 0 ? recoveryTemp - activeLast : 0;
+  const activeTemp = isNaN(activeLast) ? 0 : activeLast;
+  const recoveryCalc = recoveryTemp - activeTemp > 0 ? recoveryTemp - activeTemp : 0;
   return (recoveryCalc);
 }


### PR DESCRIPTION
display recovery frames when other frame data is not available